### PR TITLE
[NON-MODULAR] Add back survivors in distress and hunt

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -23,7 +23,7 @@
 		/datum/job/terragov/squad/smartgunner = 1,
 		/datum/job/terragov/squad/leader = 1,
 		/datum/job/terragov/squad/standard = -1,
-		/datum/job/survivor/rambo = 1,
+		/datum/job/survivor/rambo = 1, //Skyrat Edit - Survivors are added back to distress
 		/datum/job/xenomorph = 2,
 		/datum/job/xenomorph/queen = 1
 	)

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -23,6 +23,7 @@
 		/datum/job/terragov/squad/smartgunner = 1,
 		/datum/job/terragov/squad/leader = 1,
 		/datum/job/terragov/squad/standard = -1,
+		/datum/job/survivor/rambo = 1,
 		/datum/job/xenomorph = 2,
 		/datum/job/xenomorph/queen = 1
 	)

--- a/code/datums/gamemodes/hunt.dm
+++ b/code/datums/gamemodes/hunt.dm
@@ -23,7 +23,7 @@
 		/datum/job/terragov/squad/smartgunner = 1,
 		/datum/job/terragov/squad/leader = 1,
 		/datum/job/terragov/squad/standard = -1,
-		/datum/job/survivor/rambo = 1,
+		/datum/job/survivor/rambo = 1, //Skyrat Edit - Survivors are added back to hunt
 		/datum/job/xenomorph = 2,
 		/datum/job/xenomorph/queen = 1
 	)

--- a/code/datums/gamemodes/hunt.dm
+++ b/code/datums/gamemodes/hunt.dm
@@ -23,6 +23,7 @@
 		/datum/job/terragov/squad/smartgunner = 1,
 		/datum/job/terragov/squad/leader = 1,
 		/datum/job/terragov/squad/standard = -1,
+		/datum/job/survivor/rambo = 1,
 		/datum/job/xenomorph = 2,
 		/datum/job/xenomorph/queen = 1
 	)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

They are removed from upstream for some times now, but I think it's worth trying them again here.

Especially with the changes i made to maturity (so no more young t3 to die), and in modern distress (turrets + silo are here to give back xeno)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes  towould benefit the game. If you can't justify it in words, it might not be worth adding. -->

Less boring prep time for xeno, and an interesting roles for power gamers

## Changelog
:cl:
add: Add back survivors in distress and hunt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
