### PR TITLE
[UPSTREAM][DNM][TM-ONLY] Suicide vests are unusable with shields.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -297,6 +297,7 @@
 #define COMSIG_MOB_UPDATE_SIGHT "mob_update_sight"				//from base of /mob/update_sight(): ()
 #define COMSIG_MOB_HUD_CREATED "mob_hud_created"				//from base of mob/create_mob_hud(): ()
 
+#define COMSIG_MOB_SHIELD_DROPPED "mob_shield_dropped"
 #define COMSIG_MOB_ITEM_ATTACK "mob_item_attack"				//from base of /obj/item/attack(): (mob/target, /obj/item/attacking_item)
 #define COMSIG_MOB_ITEM_ATTACK_ALTERNATE "mob_item_attack_alt"	//from base of /obj/item/attack_alternate(): (mob/target, /obj/item/attacking_item)
 	#define COMPONENT_ITEM_NO_ATTACK (1<<0)						//return this if you dont want attacka and altattacks to run

--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -143,6 +143,7 @@
 		human_user.add_movespeed_modifier(parent_item.type, TRUE, 0, ((parent_item.flags_item & IMPEDE_JETPACK) ? SLOWDOWN_IMPEDE_JETPACK : NONE), TRUE, parent_item.slowdown)
 /datum/component/shield/proc/shield_dropped(datum/source, mob/user)
 	SIGNAL_HANDLER
+	SEND_SIGNAL(user, COMSIG_MOB_SHIELD_DROPPED)
 	shield_detatch_from_user()
 
 	var/obj/item/parent_item = parent //Apply in-hand slowdowns.

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -8,6 +8,23 @@
 	var/bomb_message
 	///List of warcries that are not allowed.
 	var/bad_warcries_regex = "allahu ackbar|allah|ackbar"
+	///How long must be waited after a shiled drop for detonation
+	var/shield_wait_time = 5 SECONDS
+	///Time a shiled was last dropped
+	var/shield_dropped_last = 0
+
+/obj/item/clothing/suit/storage/marine/harness/boomvest/equipped(mob/user, slot)
+	. = ..()
+	RegisterSignal(user, COMSIG_MOB_SHIELD_DROPPED, .proc/shield_dropped)
+
+/obj/item/clothing/suit/storage/marine/harness/boomvest/unequipped(mob/unequipper, slot)
+	. = ..()
+	UnregisterSignal(unequipper, COMSIG_MOB_SHIELD_DROPPED)
+
+///Updates the last shield drop time when one is dropped
+/obj/item/clothing/suit/storage/marine/harness/boomvest/proc/shield_dropped()
+	SIGNAL_HANDLER
+	shield_dropped_last = world.time
 
 ///Overwrites the parent function for activating a light. Instead it now detonates the bomb.
 /obj/item/clothing/suit/storage/marine/harness/boomvest/attack_self(mob/user)
@@ -17,6 +34,12 @@
 		return TRUE
 	if(activator.wear_suit != src)
 		to_chat(activator, "Due to the rigging of this device, it can only be detonated while worn.") //If you are going to use this, you have to accept death. No armor allowed.
+		return FALSE
+	if(istype(activator.l_hand, /obj/item/weapon/shield/riot) || istype(activator.r_hand, /obj/item/weapon/shield/riot) || istype(activator.back, /obj/item/weapon/shield/riot))
+		to_chat(activator, "<span class='warning'>Your bulky shield prevents you from reaching the detonator!</span>")
+		return FALSE
+	if(shield_dropped_last + shield_wait_time > world.time)
+		to_chat(activator, "<span class='warning'>You dropped a shield too recently to detonate, wait a few seconds!</span>")
 		return FALSE
 	if(!do_after(user, 3, TRUE, src, BUSY_ICON_DANGER, ignore_turf_checks = TRUE))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Untested, merging from master and webeditpilled 😎

Original PR: https://github.com/tgstation/TerraGov-Marine-Corps/pull/7003
## Why It's Good For The Game

It's really cheap, the Shield completely obstructs the vest, making it impossible to see it, while the suicide vest is designed around being extremely obvious.

## Changelog
:cl: Wayland-Smithy AnCopper
balance: You can no longer use suicide vests while holding a shield.
/:cl:
