### PR TITLE
[NON-MODULAR] Reload Configs Verb

### DIFF
--- a/code/modules/admin/debug_verbs.dm
+++ b/code/modules/admin/debug_verbs.dm
@@ -305,8 +305,16 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 	log_admin("[key_name(usr)] is debugging the [choice] list.")
 	message_admins("[ADMIN_TPMONTY(usr)] is debugging the [choice] list.")
-
-
+// SKYRAT EDIT ADDITION - RELOAD CONFIGS
+/datum/admins/proc/reload_configuration()
+	set category = "Debug"
+	set name = "Reload Configuration"
+	set desc = "Force config reload to world default"
+	if(!check_rights(R_DEBUG))
+		return
+	if(tgui_alert(usr, "Are you absolutely sure you want to reload the configuration from the default path on the disk, wiping any in-round modificatoins?", "Really reset?", list("No", "Yes")) == "Yes")
+		config.admin_reload()
+// SKYRAT EDIT END
 /datum/admins/proc/spawn_atom(object as text)
 	set category = "Debug"
 	set desc = "(atom path) Spawn an atom"

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -344,6 +344,7 @@ GLOBAL_PROTECT(admin_verbs_asay)
 
 /world/proc/AVdebug()
 	return list(
+	/datum/admins/proc/reload_configuration, //SKYRAT EDIT - RELOAD CONFIG
 	/datum/admins/proc/proccall_advanced,
 	/datum/admins/proc/proccall_atom,
 	/datum/admins/proc/delete_all,
@@ -505,7 +506,7 @@ GLOBAL_PROTECT(admin_verbs_spawn)
 			verbs += GLOB.admin_verbs_server
 		if(rights & R_DEBUG)
 			verbs += GLOB.admin_verbs_debug
-		if(rights & R_RUNTIME) 
+		if(rights & R_RUNTIME)
 			verbs += GLOB.admin_verbs_runtimes
 		if(rights & R_PERMISSIONS)
 			verbs += GLOB.admin_verbs_permissions


### PR DESCRIPTION
Reloading configs were in the game; there just wasn't an admin verb to actually call the proc.
Now there is.

:cl:
server: Reload Config Verb in the Debug tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
